### PR TITLE
ordering party bank clearing number padded with blanks

### DIFF
--- a/lib/payment_dta/payments/base.rb
+++ b/lib/payment_dta/payments/base.rb
@@ -5,17 +5,17 @@ module DTA
   module Payments
     class Base
       include DTA::CharacterConversion
-      
+
       def initialize(data = {})
         @data = data
       end
-      
+
       def to_dta
         dta_string(record)
       end
 
       def segment1
-        @segment1 ||= build_segment1 
+        @segment1 ||= build_segment1
       end
 
       def segment2
@@ -25,7 +25,7 @@ module DTA
       def segment3
         @segment3 ||= build_segment3
       end
-      
+
       def segment4
         @segment4 ||= build_segment4
       end
@@ -37,7 +37,7 @@ module DTA
       def segment6
         @segment6 ||= build_segment6
       end
-      
+
       def record
         @record ||= segment1 + segment2 + segment3 + segment4 + segment5 + segment6
       end
@@ -45,7 +45,7 @@ module DTA
       def header
         @header ||= build_header
       end
-      
+
       def requested_processing_date
         @data[:requested_processing_date].to_s
       end
@@ -57,7 +57,7 @@ module DTA
       def output_sequence_number
         @output_sequence_number.to_s.rjust(5,'0')
       end
-      
+
       def output_sequence_number=(output_sequence_number)
         @output_sequence_number = output_sequence_number
       end
@@ -105,11 +105,11 @@ module DTA
       def reference_number
         issuer_identification + transaction_number
       end
-      
+
       def account_to_be_debited
         @data[:account_to_be_debited].to_s.ljust(24)
       end
-      
+
       def payment_amount
         payment_amount_value_date + payment_amount_currency + payment_amount_value
       end
@@ -189,11 +189,11 @@ module DTA
       def reason_for_payment_message_line4(line_size=24)
         @data[:reason_for_payment_message_line4].to_s.ljust(line_size)
       end
-      
+
       def bank_payment_instructions
         @data[:bank_payment_instructions].to_s.ljust(120)
       end
-      
+
       def identification_bank_address
         @data[:identification_bank_address].to_s
       end
@@ -229,11 +229,11 @@ module DTA
       def beneficiary_institution_address_line4
        @data[:beneficiary_institution_address_line4].to_s.ljust(24)
       end
-      
+
       def beneficiary_iban_number
         @data[:beneficiary_iban_number].to_s.ljust(34)
       end
-      
+
       def identification_purpose
         @data[:identification_purpose].to_s[0,1]
       end
@@ -249,7 +249,7 @@ module DTA
       def rule_of_charge
         @data[:rule_of_charge].to_s[0,1]
       end
-     
+
       protected
 
       def build_segment1
@@ -263,7 +263,7 @@ module DTA
       def build_segment3
         '03'
       end
-      
+
       def build_segment4
         '04'
       end
@@ -271,18 +271,18 @@ module DTA
       def build_segment5
         '05'
       end
-      
+
       def build_segment6
         '06'
       end
-      
+
       def build_header
-        requested_processing_date + beneficiary_bank_clearing_number + output_sequence_number + creation_date + ordering_party_bank_clearing_number + data_file_sender_identification + entry_sequence_number + transaction_type + payment_type + processing_flag    
+        requested_processing_date + beneficiary_bank_clearing_number + output_sequence_number + creation_date + ordering_party_bank_clearing_number + data_file_sender_identification + entry_sequence_number + transaction_type + payment_type + processing_flag
       end
-      
+
       def reserve_field(length = 14)
        ''.ljust(length)
       end
-    end 
+    end
   end
 end

--- a/lib/payment_dta/payments/base.rb
+++ b/lib/payment_dta/payments/base.rb
@@ -67,7 +67,7 @@ module DTA
       end
 
       def ordering_party_bank_clearing_number
-        @data[:ordering_party_bank_clearing_number].to_s.ljust(7,'0')
+        @data[:ordering_party_bank_clearing_number].to_s.ljust(7,' ')
       end
 
       def data_file_sender_identification

--- a/spec/lib/payment_header_spec.rb
+++ b/spec/lib/payment_header_spec.rb
@@ -7,25 +7,25 @@ shared_examples_for "all headers" do
   it 'should have a total length of 51 characters' do
     Factory.create_payment(@type).header.size.should == 51
   end
-    
+
   it 'should fill out a blank output sequence number' do
     Factory.create_payment(@type).header[18,5].should == '00000'
   end
-  
+
   it 'should set the creation date' do
     Factory.create_payment(@type).header[23,6].should == Date.today.strftime('%y%m%d')
   end
-  
+
   it 'should set the data file sender identification' do
     Factory.create_payment(@type,:data_file_sender_identification => 'ABC12').header[36,5].should == 'ABC12'
   end
-  
+
   it 'should should set the entry sequence number' do
    Factory.create_payment(@type,:entry_sequence_number => 1).header[41,5].should == '00001'
   end
-  
+
   it 'should set the processing flag to 0' do
-   Factory.create_payment(@type).header[50,1].should == '0' 
+   Factory.create_payment(@type).header[50,1].should == '0'
   end
 end
 
@@ -33,13 +33,13 @@ describe ESRPayment, 'header' do
   before(:each) do
     @type = :esr
   end
-  
+
   it_should_behave_like 'all headers'
-  
+
   it 'should set a the correct processing date' do
     Factory.create_esr_payment(:requested_processing_date => '051021').header[0,6].should == '051021'
   end
-    
+
   it 'should fill the beneficiarys bank clearing number with blanks' do
     Factory.create_esr_payment.header[6,12].should == ''.ljust(12,' ')
   end
@@ -49,11 +49,11 @@ describe ESRPayment, 'header' do
   end
 
   it 'should should set the transaction type to 826' do
-   Factory.create_esr_payment.header[46,3].should == '826' 
+   Factory.create_esr_payment.header[46,3].should == '826'
   end
 
   it 'should set the payment type to 0' do
-   Factory.create_esr_payment.header[49,1].should == '0' 
+   Factory.create_esr_payment.header[49,1].should == '0'
   end
 end
 
@@ -62,25 +62,25 @@ describe DomesticCHFPayment, 'header' do
     @type = :domestic_chf
   end
   it_should_behave_like 'all headers'
-  
+
   it 'should set a the correct processing date' do
     Factory.create_domestic_chf_payment(:requested_processing_date => '051021').header[0,6].should == '051021'
   end
-  
+
   it 'should fill the beneficiarys bank clearing number with blanks' do
     Factory.create_domestic_chf_payment(:beneficiary_bank_clearing_number => "99999").header[6,12].should == '99999'.ljust(12,' ')
   end
-  
+
   it 'should set the ordering party bank clearing number' do
     Factory.create_domestic_chf_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
   end
-  
+
   it 'should should set the transaction type to 827' do
-   Factory.create_domestic_chf_payment.header[46,3].should == '827' 
+   Factory.create_domestic_chf_payment.header[46,3].should == '827'
   end
 
   it 'should set the payment type to 0' do
-   Factory.create_domestic_chf_payment.header[49,1].should == '0' 
+   Factory.create_domestic_chf_payment.header[49,1].should == '0'
   end
 end
 
@@ -88,27 +88,27 @@ describe FinancialInstitutionPayment, 'header' do
   before(:each) do
     @type = :financial_institution
   end
-  
+
   it_should_behave_like 'all headers'
-  
+
   it 'should fill the requested processing date with zeros' do
     Factory.create_financial_institution_payment.header[0,6].should == '000000'
   end
-  
+
   it 'should fill the beneficiarys bank clearing number with blanks' do
     Factory.create_financial_institution_payment.header[6,12].should == ''.ljust(12,' ')
   end
-  
+
   it 'should set the ordering party bank clearing number' do
     Factory.create_financial_institution_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
   end
 
   it 'should should set the transaction type to 830' do
-   Factory.create_financial_institution_payment.header[46,3].should == '830' 
+   Factory.create_financial_institution_payment.header[46,3].should == '830'
   end
 
   it 'should set the payment type to 0' do
-   Factory.create_financial_institution_payment.header[49,1].should == '0' 
+   Factory.create_financial_institution_payment.header[49,1].should == '0'
   end
 end
 
@@ -116,27 +116,27 @@ describe BankChequePayment, 'header' do
   before(:each) do
     @type = :bank_cheque
   end
-  
+
   it_should_behave_like 'all headers'
-  
+
   it 'should fill the requested processing date with zeros' do
     Factory.create_bank_cheque_payment.header[0,6].should == '000000'
   end
-  
+
   it 'should fill the beneficiarys bank clearing number with blanks' do
     Factory.create_bank_cheque_payment.header[6,12].should == ''.ljust(12,' ')
   end
-  
+
   it 'should set the ordering party bank clearing number' do
     Factory.create_bank_cheque_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
   end
-  
+
   it 'should should set the transaction type to 832' do
-   Factory.create_bank_cheque_payment.header[46,3].should == '832' 
+   Factory.create_bank_cheque_payment.header[46,3].should == '832'
   end
 
   it 'should set the payment type to 0' do
-   Factory.create_bank_cheque_payment.header[49,1].should == '0' 
+   Factory.create_bank_cheque_payment.header[49,1].should == '0'
   end
 end
 
@@ -144,27 +144,27 @@ describe IBANPayment, 'header' do
   before(:each) do
     @type = :iban
   end
-  
+
   it_should_behave_like 'all headers'
-  
+
   it 'should fill the requested processing date with zeros' do
     Factory.create_iban_payment.header[0,6].should == '000000'
   end
-  
+
   it 'should fill the beneficiarys bank clearing number with blanks' do
     Factory.create_iban_payment.header[6,12].should == ''.ljust(12,' ')
   end
-  
+
   it 'should set the ordering party bank clearing number' do
     Factory.create_iban_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
   end
-  
+
   it 'should should set the transaction type to 836' do
-   Factory.create_iban_payment.header[46,3].should == '836' 
+   Factory.create_iban_payment.header[46,3].should == '836'
   end
 
   it 'should set the payment type to 1' do
-   Factory.create_iban_payment.header[49,1].should == '1' 
+   Factory.create_iban_payment.header[49,1].should == '1'
   end
 end
 
@@ -172,27 +172,27 @@ describe SpecialFinancialInstitutionPayment, 'header' do
   before(:each) do
     @type = :special_financial_institution
   end
-  
+
   it_should_behave_like 'all headers'
-  
+
   it 'should fill the requested processing date with zeros' do
     Factory.create_special_financial_institution_payment.header[0,6].should == '000000'
   end
-  
+
   it 'should fill the beneficiarys bank clearing number with blanks' do
     Factory.create_special_financial_institution_payment.header[6,12].should == ''.ljust(12,' ')
   end
-  
+
   it 'should set the ordering party bank clearing number' do
     Factory.create_special_financial_institution_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
   end
 
   it 'should should set the transaction type to 837' do
-   Factory.create_special_financial_institution_payment.header[46,3].should == '837' 
+   Factory.create_special_financial_institution_payment.header[46,3].should == '837'
   end
 
   it 'should set the payment type to 1' do
-   Factory.create_special_financial_institution_payment.header[49,1].should == '1' 
+   Factory.create_special_financial_institution_payment.header[49,1].should == '1'
   end
 end
 
@@ -200,21 +200,21 @@ describe TotalRecord, 'header' do
   before(:each) do
     @type = :total
   end
-  
+
   it_should_behave_like 'all headers'
-  
+
   it 'should fill the ordering party bank clearing number with blanks' do
     Factory.create_total_payment.header[29,7].should == '       '
   end
-  
+
   it 'should should set the transaction type to 890' do
-   Factory.create_total_payment.header[46,3].should == '890' 
+   Factory.create_total_payment.header[46,3].should == '890'
   end
-  
+
   it 'should set the payment type to 0' do
-   Factory.create_total_payment.header[49,1].should == '0' 
+   Factory.create_total_payment.header[49,1].should == '0'
   end
-  
+
   it 'should set a the correct processing date' do
     Factory.create_total_payment.header[0,6].should == '000000'
   end

--- a/spec/lib/payment_header_spec.rb
+++ b/spec/lib/payment_header_spec.rb
@@ -45,7 +45,7 @@ describe ESRPayment, 'header' do
   end
 
   it 'should set the ordering party bank clearing number' do
-    Factory.create_esr_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
+    Factory.create_esr_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '254    '
   end
 
   it 'should should set the transaction type to 826' do
@@ -72,7 +72,7 @@ describe DomesticCHFPayment, 'header' do
   end
 
   it 'should set the ordering party bank clearing number' do
-    Factory.create_domestic_chf_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
+    Factory.create_domestic_chf_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '254    '
   end
 
   it 'should should set the transaction type to 827' do
@@ -100,7 +100,7 @@ describe FinancialInstitutionPayment, 'header' do
   end
 
   it 'should set the ordering party bank clearing number' do
-    Factory.create_financial_institution_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
+    Factory.create_financial_institution_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '254    '
   end
 
   it 'should should set the transaction type to 830' do
@@ -128,7 +128,7 @@ describe BankChequePayment, 'header' do
   end
 
   it 'should set the ordering party bank clearing number' do
-    Factory.create_bank_cheque_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
+    Factory.create_bank_cheque_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '254    '
   end
 
   it 'should should set the transaction type to 832' do
@@ -156,7 +156,7 @@ describe IBANPayment, 'header' do
   end
 
   it 'should set the ordering party bank clearing number' do
-    Factory.create_iban_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
+    Factory.create_iban_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '254    '
   end
 
   it 'should should set the transaction type to 836' do
@@ -184,7 +184,7 @@ describe SpecialFinancialInstitutionPayment, 'header' do
   end
 
   it 'should set the ordering party bank clearing number' do
-    Factory.create_special_financial_institution_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '2540000'
+    Factory.create_special_financial_institution_payment(:ordering_party_bank_clearing_number => '254').header[29,7].should == '254    '
   end
 
   it 'should should set the transaction type to 837' do


### PR DESCRIPTION
Adjusted the ordering_party_bank_clearing_number to match the specification (padded by blanks)

I included a commit to remove all the trailing whitespace. If you are somehow attached to the whitespace you can simple merge the second commit, which contains the necessary change.

Cheers
-- Yves
